### PR TITLE
Add Profile Picture Upload Size Validation (2MB Limit)

### DIFF
--- a/public/css/pages/user-profile.css
+++ b/public/css/pages/user-profile.css
@@ -317,6 +317,14 @@ body {
     height: 100%;
 }
 
+.file-size-hint {
+    display: block;
+    color: #999;
+    font-size: 0.85rem;
+    margin-top: 5px;
+    font-style: italic;
+}
+
 .btn-remove-avatar {
     background: transparent;
     color: #ff4c4c;

--- a/public/js/user-profile.js
+++ b/public/js/user-profile.js
@@ -27,6 +27,22 @@ document.addEventListener('DOMContentLoaded', function() {
         avatarInput.addEventListener('change', function(e) {
             const file = e.target.files[0];
             if (file) {
+                // Check file size (2MB limit)
+                const maxSize = 2 * 1024 * 1024; // 2MB in bytes
+                if (file.size > maxSize) {
+                    alert('File size exceeds 2MB limit. Please choose a smaller image.');
+                    avatarInput.value = ''; // Clear the input
+                    return;
+                }
+
+                // Check file type
+                const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
+                if (!allowedTypes.includes(file.type)) {
+                    alert('Please select a valid image file (JPG, JPEG, PNG, or GIF).');
+                    avatarInput.value = ''; // Clear the input
+                    return;
+                }
+
                 const reader = new FileReader();
                 reader.onload = function(e) {
                     avatarPreview.src = e.target.result;

--- a/public/php/update_profile.php
+++ b/public/php/update_profile.php
@@ -40,6 +40,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             mkdir($targetDir, 0777, true);
         }
 
+        // Check file size (2MB limit)
+        $maxSize = 2 * 1024 * 1024; // 2MB in bytes
+        if ($_FILES['avatar']['size'] > $maxSize) {
+            $_SESSION['error'] = "File size exceeds 2MB limit. Please choose a smaller image.";
+            header("Location: user_profile.php");
+            exit;
+        }
+
         $fileExtension = strtolower(pathinfo($_FILES["avatar"]["name"], PATHINFO_EXTENSION));
         $newFileName = uniqid() . '.' . $fileExtension;
         $targetFile = $targetDir . $newFileName;
@@ -49,7 +57,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if (in_array($fileExtension, $allowedTypes)) {
             if (move_uploaded_file($_FILES["avatar"]["tmp_name"], $targetFile)) {
                 $avatar = $newFileName;
+            } else {
+                $_SESSION['error'] = "Failed to upload avatar image.";
+                header("Location: user_profile.php");
+                exit;
             }
+        } else {
+            $_SESSION['error'] = "Invalid file type. Only JPG, JPEG, PNG, and GIF are allowed.";
+            header("Location: user_profile.php");
+            exit;
         }
     }
 

--- a/public/php/user_profile.php
+++ b/public/php/user_profile.php
@@ -158,6 +158,7 @@ $avatarSrc = $hasCustomAvatar ? "../../uploads/avatars/" . htmlspecialchars($use
                             </div>
                             <input type="file" name="avatar" id="avatarInput" accept="image/*">
                         </div>
+                        <small class="file-size-hint">Maximum file size: 2MB</small>
                         <button type="button" class="btn-remove-avatar <?= $hasCustomAvatar ? 'show' : '' ?>" id="removeAvatarBtn">
                             <i class="fas fa-trash"></i> Remove Photo
                         </button>


### PR DESCRIPTION
This commit implements comprehensive file size validation for profile picture uploads to enhance user experience and prevent server overload.

Changes:
- Added client-side validation in user-profile.js:
  * File size check (2MB maximum)
  * File type validation (JPG, JPEG, PNG, GIF)
  * User-friendly alert messages for validation failures
  * Auto-clear input on validation failure

- Added visual size limit indicator in user_profile.php:
  * Small, subtle text below "Choose Photo" button
  * Displays "Maximum file size: 2MB" message
  * Improves user awareness before upload attempt
